### PR TITLE
feat: add user notification settings page

### DIFF
--- a/auth-service/src/main/kotlin/com/lcaohoanq/authservice/domains/auth/AuthService.kt
+++ b/auth-service/src/main/kotlin/com/lcaohoanq/authservice/domains/auth/AuthService.kt
@@ -20,7 +20,7 @@ import com.lcaohoanq.authservice.utils.getClientIp
 import com.lcaohoanq.authservice.utils.getUserAgent
 import com.lcaohoanq.common.dto.AuthPort
 import com.lcaohoanq.common.dto.TokenPort
-import com.lcaohoanq.common.dto.UserPort.UserResponse
+import com.lcaohoanq.authservice.domains.user.UserPort.UserResponse
 import com.lcaohoanq.common.enums.UserEnum
 import com.lcaohoanq.common.exceptions.ExpiredTokenException
 import com.lcaohoanq.common.exceptions.MalformBehaviourException
@@ -152,15 +152,18 @@ class AuthService(
         savedUser.userSettings = savedSettings
         userRepository.save(savedUser)
 
-        addressRepository.save(
-            Address(
-                address = newAccount.address,
-                isDefault = true,
-                phoneNumber = newAccount.phoneNumber,
-                nameOfUser = newAccount.name,
-                userId = savedUser.id!!
-            )
+        val address =  Address(
+            address = newAccount.address,
+            isDefault = true,
+            phoneNumber = newAccount.phoneNumber,
+            nameOfUser = newAccount.name,
+            user = savedUser
         )
+        val savedAddress = addressRepository.save(address)
+
+        // Assign the address to the user and save again
+        savedUser.address = mutableListOf(savedAddress)
+        userRepository.save(savedUser)
 
         mailFeignClient.sendVerifyAccountEmail(
             AuthPort.VerifyEmailReq(newAccount.email)

--- a/auth-service/src/main/kotlin/com/lcaohoanq/authservice/domains/auth/IAuthService.kt
+++ b/auth-service/src/main/kotlin/com/lcaohoanq/authservice/domains/auth/IAuthService.kt
@@ -2,7 +2,7 @@ package com.lcaohoanq.authservice.domains.auth
 
 import com.lcaohoanq.authservice.domains.user.User
 import com.lcaohoanq.common.dto.TokenPort
-import com.lcaohoanq.common.dto.UserPort
+import com.lcaohoanq.authservice.domains.user.UserPort
 import com.lcaohoanq.common.dto.AuthPort
 
 

--- a/auth-service/src/main/kotlin/com/lcaohoanq/authservice/domains/settings/UserSettings.kt
+++ b/auth-service/src/main/kotlin/com/lcaohoanq/authservice/domains/settings/UserSettings.kt
@@ -2,6 +2,7 @@ package com.lcaohoanq.authservice.domains.settings
 
 import BaseEntity
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.lcaohoanq.authservice.domains.settings.notifications.NotificationSettings
 import jakarta.persistence.*
 
 @Entity
@@ -31,8 +32,22 @@ class UserSettings(
     @Column(name = "dark_mode")
     var darkMode: Boolean = false,
 
-    @Column(name = "email_notifications_enabled")
-    var emailNotificationsEnabled: Boolean = true,
+    @Embedded
+    @AttributeOverrides(
+        value = [
+            AttributeOverride(name = "emailMasterEnabled", column = Column(name = "email_master_enabled")),
+            AttributeOverride(name = "emailOrder", column = Column(name = "email_order")),
+            AttributeOverride(name = "emailPromo", column = Column(name = "email_promo")),
+            AttributeOverride(name = "emailSurvey", column = Column(name = "email_survey")),
+
+            AttributeOverride(name = "smsMasterEnabled", column = Column(name = "sms_master_enabled")),
+            AttributeOverride(name = "smsPromo", column = Column(name = "sms_promo")),
+
+            AttributeOverride(name = "zaloMasterEnabled", column = Column(name = "zalo_master_enabled")),
+            AttributeOverride(name = "zaloPromo", column = Column(name = "zalo_promo")),
+        ]
+    )
+    var notificationSettings: NotificationSettings = NotificationSettings(),
 
     @Column(name = "login_alerts")
     var loginAlerts: Boolean = true,

--- a/auth-service/src/main/kotlin/com/lcaohoanq/authservice/domains/settings/UserSettingsController.kt
+++ b/auth-service/src/main/kotlin/com/lcaohoanq/authservice/domains/settings/UserSettingsController.kt
@@ -3,7 +3,7 @@ package com.lcaohoanq.authservice.domains.settings
 import com.lcaohoanq.authservice.extension.toUserSettingsResponse
 import com.lcaohoanq.authservice.repositories.UserSettingsRepository
 import com.lcaohoanq.common.apis.MyApiResponse
-import com.lcaohoanq.common.dto.UserPort
+import com.lcaohoanq.authservice.domains.user.UserPort
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity

--- a/auth-service/src/main/kotlin/com/lcaohoanq/authservice/domains/settings/notifications/EmailNotificationSettings.kt
+++ b/auth-service/src/main/kotlin/com/lcaohoanq/authservice/domains/settings/notifications/EmailNotificationSettings.kt
@@ -1,0 +1,19 @@
+package com.lcaohoanq.authservice.domains.settings.notifications
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+
+@Embeddable
+class EmailNotificationSettings(
+    @Column(name = "email_master_enabled")
+    var masterEnabled: Boolean = true,
+
+    @Column(name = "email_order")
+    var order: Boolean = true,
+
+    @Column(name = "email_promo")
+    var promo: Boolean = true,
+
+    @Column(name = "email_survey")
+    var survey: Boolean = true,
+)

--- a/auth-service/src/main/kotlin/com/lcaohoanq/authservice/domains/settings/notifications/NotificationSettings.kt
+++ b/auth-service/src/main/kotlin/com/lcaohoanq/authservice/domains/settings/notifications/NotificationSettings.kt
@@ -1,0 +1,18 @@
+package com.lcaohoanq.authservice.domains.settings.notifications
+
+import jakarta.persistence.Embeddable
+import jakarta.persistence.Embedded
+
+
+@Embeddable
+class NotificationSettings(
+    @Embedded
+    var email: EmailNotificationSettings = EmailNotificationSettings(),
+
+    @Embedded
+    var sms: SmsNotificationSettings = SmsNotificationSettings(),
+
+    @Embedded
+    var zalo: ZaloNotificationSettings = ZaloNotificationSettings(),
+)
+

--- a/auth-service/src/main/kotlin/com/lcaohoanq/authservice/domains/settings/notifications/SmsNotificationSettings.kt
+++ b/auth-service/src/main/kotlin/com/lcaohoanq/authservice/domains/settings/notifications/SmsNotificationSettings.kt
@@ -1,0 +1,13 @@
+package com.lcaohoanq.authservice.domains.settings.notifications
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+
+@Embeddable
+class SmsNotificationSettings(
+    @Column(name = "sms_master_enabled")
+    var masterEnabled: Boolean = true,
+
+    @Column(name = "sms_promo")
+    var promo: Boolean = false,
+)

--- a/auth-service/src/main/kotlin/com/lcaohoanq/authservice/domains/settings/notifications/ZaloNotificationSettings.kt
+++ b/auth-service/src/main/kotlin/com/lcaohoanq/authservice/domains/settings/notifications/ZaloNotificationSettings.kt
@@ -1,0 +1,13 @@
+package com.lcaohoanq.authservice.domains.settings.notifications
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+
+@Embeddable
+class ZaloNotificationSettings(
+    @Column(name = "zalo_master_enabled")
+    var masterEnabled: Boolean = true,
+
+    @Column(name = "zalo_promo")
+    var promo: Boolean = true,
+)

--- a/auth-service/src/main/kotlin/com/lcaohoanq/authservice/domains/user/Address.kt
+++ b/auth-service/src/main/kotlin/com/lcaohoanq/authservice/domains/user/Address.kt
@@ -1,5 +1,6 @@
 package com.lcaohoanq.authservice.domains.user
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.persistence.*
 
@@ -20,7 +21,10 @@ class Address(
     val phoneNumber: String = "",
     val address: String = "",
     val isDefault: Boolean = false,
-    val userId: Long,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    @JsonIgnore
+    val user: User,
 
 ) {
 }

--- a/auth-service/src/main/kotlin/com/lcaohoanq/authservice/domains/user/IUserService.kt
+++ b/auth-service/src/main/kotlin/com/lcaohoanq/authservice/domains/user/IUserService.kt
@@ -1,7 +1,6 @@
 package com.lcaohoanq.authservice.domains.user
 
 import com.lcaohoanq.common.apis.PageResponse
-import com.lcaohoanq.common.dto.UserPort
 import com.lcaohoanq.common.metadata.QueryCriteria
 import com.lcaohoanq.common.utils.Sortable
 import org.springframework.data.domain.Pageable

--- a/auth-service/src/main/kotlin/com/lcaohoanq/authservice/domains/user/User.kt
+++ b/auth-service/src/main/kotlin/com/lcaohoanq/authservice/domains/user/User.kt
@@ -48,6 +48,9 @@ class User(
 
     val avatar: String = "",
 
+    @OneToMany(mappedBy = "user", cascade = [CascadeType.ALL], orphanRemoval = true)
+    var address: MutableList<Address> = mutableListOf(),
+
     val cartId: String,
 
     val walletId: String,

--- a/auth-service/src/main/kotlin/com/lcaohoanq/authservice/domains/user/UserController.kt
+++ b/auth-service/src/main/kotlin/com/lcaohoanq/authservice/domains/user/UserController.kt
@@ -1,7 +1,6 @@
 package com.lcaohoanq.authservice.domains.user
 
 import com.lcaohoanq.authservice.domains.auth.IAuthService
-import com.lcaohoanq.common.dto.UserPort
 import com.lcaohoanq.authservice.extension.toUserResponse
 import com.lcaohoanq.common.apis.MyApiResponse
 import com.lcaohoanq.common.apis.PageResponse

--- a/auth-service/src/main/kotlin/com/lcaohoanq/authservice/domains/user/UserPort.kt
+++ b/auth-service/src/main/kotlin/com/lcaohoanq/authservice/domains/user/UserPort.kt
@@ -3,6 +3,9 @@ package com.lcaohoanq.authservice.domains.user
 import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
+import com.lcaohoanq.authservice.domains.settings.notifications.NotificationSettings
+import com.lcaohoanq.common.dto.AddressPort
+import com.lcaohoanq.common.dto.LoginHistoryPort
 import com.lcaohoanq.common.enums.UserEnum
 import java.time.LocalDateTime
 
@@ -16,16 +19,32 @@ interface UserPort {
     @JsonPropertyOrder("id", "email", "username", "status", "phone", "address", "avatar")
     data class UserResponse(
         val id: Long,
-        val address: Set<AddressPort.AddressResponse>? = null,
         val avatar: String,
         val email: String,
         val role: UserEnum.Role,
+        val totp: String,
         val username: String,
+        val address: MutableList<AddressPort.AddressResponse>,
         val status: UserEnum.Status,
+        val loginHistory: MutableList<LoginHistoryPort.LoginHistoryResponse>,
+        val settings: UserSettingsResponse?,
         @JsonIgnore val password: String,
-        val phone : String,
+        val phone: String,
         @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "Asia/Ho_Chi_Minh") @JsonIgnore val createdAt: LocalDateTime?,
         @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "Asia/Ho_Chi_Minh") @JsonIgnore val updatedAt: LocalDateTime?
+    )
+
+    data class UserSettingsResponse(
+        val id: Long = 0,
+//        val userId: Long,
+        val twoFaEnabled: Boolean = false,
+        val preferredLanguage: String = "en",
+        val darkMode: Boolean = false,
+        val notificationSettings: NotificationSettings = NotificationSettings(),
+        val loginAlerts: Boolean = true,
+        val requestDisableAccount: Boolean = false,
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "Asia/Ho_Chi_Minh") @JsonIgnore val createdAt: LocalDateTime? = null,
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "Asia/Ho_Chi_Minh") @JsonIgnore val updatedAt: LocalDateTime? = null
     )
 
 }

--- a/auth-service/src/main/kotlin/com/lcaohoanq/authservice/domains/user/UserService.kt
+++ b/auth-service/src/main/kotlin/com/lcaohoanq/authservice/domains/user/UserService.kt
@@ -3,7 +3,6 @@ package com.lcaohoanq.authservice.domains.user
 import com.lcaohoanq.authservice.components.JwtTokenUtils
 import com.lcaohoanq.authservice.extension.UserResponseOptions
 import com.lcaohoanq.authservice.extension.toLoginHistoryResponse
-import com.lcaohoanq.common.dto.UserPort
 import com.lcaohoanq.authservice.extension.toUserResponse
 import com.lcaohoanq.authservice.extension.toUserSettingsResponse
 import com.lcaohoanq.authservice.repositories.LoginHistoryRepository

--- a/auth-service/src/main/kotlin/com/lcaohoanq/authservice/extension/UserExtensions.kt
+++ b/auth-service/src/main/kotlin/com/lcaohoanq/authservice/extension/UserExtensions.kt
@@ -2,7 +2,7 @@ package com.lcaohoanq.authservice.extension
 
 import com.lcaohoanq.authservice.domains.user.User
 import com.lcaohoanq.common.dto.LoginHistoryPort
-import com.lcaohoanq.common.dto.UserPort
+import com.lcaohoanq.authservice.domains.user.UserPort
 
 data class UserResponseOptions(
     val includeLoginHistory: Boolean = false,
@@ -36,6 +36,7 @@ fun User.toUserResponse(
 
         role = role!!,
         avatar = avatar,
+        address = address.map { it.toAddressResponse() }.toMutableList(),
         createdAt = createdAt,
         updatedAt = updatedAt
     )

--- a/auth-service/src/main/kotlin/com/lcaohoanq/authservice/extension/UserSettingsExtensions.kt
+++ b/auth-service/src/main/kotlin/com/lcaohoanq/authservice/extension/UserSettingsExtensions.kt
@@ -1,14 +1,14 @@
 package com.lcaohoanq.authservice.extension
 
 import com.lcaohoanq.authservice.domains.settings.UserSettings
-import com.lcaohoanq.common.dto.UserPort
+import com.lcaohoanq.authservice.domains.user.UserPort
 
 fun UserSettings.toUserSettingsResponse() = UserPort.UserSettingsResponse(
     id = this.id!!,
     twoFaEnabled = this.twoFaEnabled,
     preferredLanguage = this.preferredLanguage,
     darkMode = this.darkMode,
-    emailNotificationsEnabled = this.emailNotificationsEnabled,
+    notificationSettings = this.notificationSettings,
     loginAlerts = this.loginAlerts,
     requestDisableAccount = this.requestDisableAccount,
     createdAt = this.createdAt,

--- a/auth-service/src/main/kotlin/com/lcaohoanq/authservice/repositories/AddressRepository.kt
+++ b/auth-service/src/main/kotlin/com/lcaohoanq/authservice/repositories/AddressRepository.kt
@@ -1,7 +1,9 @@
 package com.lcaohoanq.authservice.repositories
 
 import com.lcaohoanq.authservice.domains.user.Address
+import com.lcaohoanq.authservice.domains.user.User
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface AddressRepository: JpaRepository<Address, Long> {
+    fun user(user: User): MutableList<Address>
 }

--- a/libs/common-lib/src/main/kotlin/com/lcaohoanq/common/dto/NotificationSettings.kt
+++ b/libs/common-lib/src/main/kotlin/com/lcaohoanq/common/dto/NotificationSettings.kt
@@ -1,0 +1,25 @@
+package com.lcaohoanq.common.dto
+
+data class NotificationSettingsDto(
+    val email: EmailNotificationSettingsDto,
+    val sms: SmsNotificationSettingsDto,
+    val zalo: ZaloNotificationSettingsDto,
+)
+
+data class EmailNotificationSettingsDto(
+    val masterEnabled: Boolean,
+    val order: Boolean,
+    val promo: Boolean,
+    val survey: Boolean,
+)
+
+data class SmsNotificationSettingsDto(
+    val masterEnabled: Boolean,
+    val promo: Boolean,
+)
+
+data class ZaloNotificationSettingsDto(
+    val masterEnabled: Boolean,
+    val promo: Boolean,
+)
+

--- a/libs/common-lib/src/main/kotlin/com/lcaohoanq/common/dto/UserPort.kt
+++ b/libs/common-lib/src/main/kotlin/com/lcaohoanq/common/dto/UserPort.kt
@@ -22,12 +22,19 @@ interface UserPort {
         val totp: String,
         val username: String,
         val status: UserEnum.Status,
+        val address: MutableList<AddressPort.AddressResponse>,
         val loginHistory: MutableList<LoginHistoryPort.LoginHistoryResponse>,
         val settings: UserPort.UserSettingsResponse?,
         @JsonIgnore val password: String,
         val phone: String,
-        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "Asia/Ho_Chi_Minh") @JsonIgnore val createdAt: LocalDateTime?,
-        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "Asia/Ho_Chi_Minh") @JsonIgnore val updatedAt: LocalDateTime?
+        @JsonFormat(
+            pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+            timezone = "Asia/Ho_Chi_Minh"
+        ) @JsonIgnore val createdAt: LocalDateTime?,
+        @JsonFormat(
+            pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+            timezone = "Asia/Ho_Chi_Minh"
+        ) @JsonIgnore val updatedAt: LocalDateTime?
     )
 
     data class UserSettingsResponse(
@@ -36,11 +43,17 @@ interface UserPort {
         val twoFaEnabled: Boolean = false,
         val preferredLanguage: String = "en",
         val darkMode: Boolean = false,
-        val emailNotificationsEnabled: Boolean = true,
+        val notificationSettings: NotificationSettingsDto,
         val loginAlerts: Boolean = true,
         val requestDisableAccount: Boolean = false,
-        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "Asia/Ho_Chi_Minh") @JsonIgnore val createdAt: LocalDateTime? = null,
-        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "Asia/Ho_Chi_Minh") @JsonIgnore val updatedAt: LocalDateTime? = null
+        @JsonFormat(
+            pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+            timezone = "Asia/Ho_Chi_Minh"
+        ) @JsonIgnore val createdAt: LocalDateTime? = null,
+        @JsonFormat(
+            pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+            timezone = "Asia/Ho_Chi_Minh"
+        ) @JsonIgnore val updatedAt: LocalDateTime? = null
     )
 
 }

--- a/react-client/package-lock.json
+++ b/react-client/package-lock.json
@@ -11,6 +11,7 @@
         "@emotion/react": "^11.13.5",
         "@emotion/styled": "^11.13.5",
         "@floating-ui/react": "^0.24.6",
+        "@headlessui/react": "^2.2.1",
         "@hookform/resolvers": "^3.1.1",
         "@mui/icons-material": "^6.4.1",
         "@mui/material": "^6.4.1",
@@ -2687,6 +2688,40 @@
       "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==",
       "license": "MIT"
     },
+    "node_modules/@headlessui/react": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.2.1.tgz",
+      "integrity": "sha512-daiUqVLae8CKVjEVT19P/izW0aGK0GNhMSAeMlrDebKmoVZHcRRwbxzgtnEadUVDXyBsWo9/UH4KHeniO+0tMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.26.16",
+        "@react-aria/focus": "^3.17.1",
+        "@react-aria/interactions": "^3.21.3",
+        "@tanstack/react-virtual": "^3.11.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@headlessui/react/node_modules/@floating-ui/react": {
+      "version": "0.26.28",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.28.tgz",
+      "integrity": "sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.2",
+        "@floating-ui/utils": "^0.2.8",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/@hookform/resolvers": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.9.1.tgz",
@@ -4838,6 +4873,103 @@
         "@babel/runtime": "^7.13.10"
       }
     },
+    "node_modules/@react-aria/focus": {
+      "version": "3.20.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.20.2.tgz",
+      "integrity": "sha512-Q3rouk/rzoF/3TuH6FzoAIKrl+kzZi9LHmr8S5EqLAOyP9TXIKG34x2j42dZsAhrw7TbF9gA8tBKwnCNH4ZV+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.0",
+        "@react-aria/utils": "^3.28.2",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/interactions": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.25.0.tgz",
+      "integrity": "sha512-GgIsDLlO8rDU/nFn6DfsbP9rfnzhm8QFjZkB9K9+r+MTSCn7bMntiWQgMM+5O6BiA8d7C7x4zuN4bZtc0RBdXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.8",
+        "@react-aria/utils": "^3.28.2",
+        "@react-stately/flags": "^3.1.1",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/ssr": {
+      "version": "3.9.8",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.8.tgz",
+      "integrity": "sha512-lQDE/c9uTfBSDOjaZUJS8xP2jCKVk4zjQeIlCH90xaLhHDgbpCdns3xvFpJJujfj3nI4Ll9K7A+ONUBDCASOuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/utils": {
+      "version": "3.28.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.28.2.tgz",
+      "integrity": "sha512-J8CcLbvnQgiBn54eeEvQQbIOfBF3A1QizxMw9P4cl9MkeR03ug7RnjTIdJY/n2p7t59kLeAB3tqiczhcj+Oi5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.8",
+        "@react-stately/flags": "^3.1.1",
+        "@react-stately/utils": "^3.10.6",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/flags": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.1.1.tgz",
+      "integrity": "sha512-XPR5gi5LfrPdhxZzdIlJDz/B5cBf63l4q6/AzNqVWFKgd0QqY5LvWJftXkklaIUpKSJkIKQb8dphuZXDtkWNqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@react-stately/utils": {
+      "version": "3.10.6",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.6.tgz",
+      "integrity": "sha512-O76ip4InfTTzAJrg8OaZxKU4vvjMDOpfA/PGNOytiXwBbkct2ZeZwaimJ8Bt9W1bj5VsZ81/o/tW4BacbdDOMA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/shared": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.29.0.tgz",
+      "integrity": "sha512-IDQYu/AHgZimObzCFdNl1LpZvQW/xcfLt3v20sorl5qRucDVj4S9os98sVTZ4IRIBjmS+MkjqpR5E70xan7ooA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.21.0.tgz",
@@ -6072,6 +6204,15 @@
         "url": "https://opencollective.com/storybook"
       }
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@tanstack/match-sorter-utils": {
       "version": "8.19.4",
       "resolved": "https://registry.npmjs.org/@tanstack/match-sorter-utils/-/match-sorter-utils-8.19.4.tgz",
@@ -6143,6 +6284,33 @@
         "@tanstack/react-query": "^4.36.1",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.6.tgz",
+      "integrity": "sha512-WT7nWs8ximoQ0CDx/ngoFP7HbQF9Q2wQe4nh2NB+u2486eX3nZRE40P9g6ccCVq7ZfTSH5gFOuCoVH5DLNS/aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.6.tgz",
+      "integrity": "sha512-cnQUeWnhNP8tJ4WsGcYiX24Gjkc9ALstLbHcBj1t3E7EimN6n6kHH+DPV4PpDnuw00NApQp+ViojMj1GRdwYQg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/react-client/package.json
+++ b/react-client/package.json
@@ -20,6 +20,7 @@
     "@emotion/react": "^11.13.5",
     "@emotion/styled": "^11.13.5",
     "@floating-ui/react": "^0.24.6",
+    "@headlessui/react": "^2.2.1",
     "@hookform/resolvers": "^3.1.1",
     "@mui/icons-material": "^6.4.1",
     "@mui/material": "^6.4.1",

--- a/react-client/src/pages/User/pages/Account/SettingNotify/UserSettingNotify.tsx
+++ b/react-client/src/pages/User/pages/Account/SettingNotify/UserSettingNotify.tsx
@@ -6,46 +6,51 @@ function classNames(...classes: string[]) {
 }
 
 const UserSettingNotify = () => {
-  // Master toggles for sections
-  const [emailMasterEnabled, setEmailMasterEnabled] = useState(true)
-  const [smsMasterEnabled, setSmsMasterEnabled] = useState(true)
-  const [zaloMasterEnabled, setZaloMasterEnabled] = useState(true)
+  // Email group
+  const [emailSettings, setEmailSettings] = useState({
+    masterEnabled: true,
+    order: true,
+    promo: true,
+    survey: true,
+  })
 
-  // Individual notification states
-  const [emailOrder, setEmailOrder] = useState(true)
-  const [emailPromo, setEmailPromo] = useState(true)
-  const [emailSurvey, setEmailSurvey] = useState(true)
+  // SMS group
+  const [smsSettings, setSmsSettings] = useState({
+    masterEnabled: false,
+    promo: false,
+  })
 
-  const [smsNotify, setSmsNotify] = useState(true)
-  const [smsPromo, setSmsPromo] = useState(false)
-
-  const [zaloNotify, setZaloNotify] = useState(true)
-  const [zaloPromo, setZaloPromo] = useState(true)
-
-  // Update individual settings when master toggle changes
-  useEffect(() => {
-    if (!emailMasterEnabled) {
-      setEmailOrder(false)
-      setEmailPromo(false)
-      setEmailSurvey(false)
-    }
-  }, [emailMasterEnabled])
+  // Zalo group
+  const [zaloSettings, setZaloSettings] = useState({
+    masterEnabled: false,
+    promo: true,
+  })
 
   useEffect(() => {
-    if (!smsMasterEnabled) {
-      setSmsNotify(false)
-      setSmsPromo(false)
+    if (!emailSettings.masterEnabled) {
+      setEmailSettings((prev) => ({ ...prev, order: false, promo: false, survey: false }))
     }
-  }, [smsMasterEnabled])
+  }, [emailSettings.masterEnabled])
 
   useEffect(() => {
-    if (!zaloMasterEnabled) {
-      setZaloNotify(false)
-      setZaloPromo(false)
+    if (!smsSettings.masterEnabled) {
+      setSmsSettings((prev) => ({ ...prev, promo: false }))
     }
-  }, [zaloMasterEnabled])
+  }, [smsSettings.masterEnabled])
 
-  const renderItem = (title: string, desc: string, enabled: boolean, setEnabled: (v: boolean) => void, masterEnabled: boolean) => (
+  useEffect(() => {
+    if (!zaloSettings.masterEnabled) {
+      setZaloSettings((prev) => ({ ...prev, promo: false }))
+    }
+  }, [zaloSettings.masterEnabled])
+
+  const renderItem = (
+    title: string,
+    desc: string,
+    enabled: boolean,
+    setEnabled: (v: boolean) => void,
+    masterEnabled: boolean
+  ) => (
     <div className={`flex justify-between items-start py-3 border-b border-gray-100 ${!masterEnabled ? 'opacity-50' : ''}`}>
       <div>
         <div className="text-black text-[16px] font-medium">{title}</div>
@@ -70,17 +75,20 @@ const UserSettingNotify = () => {
     </div>
   )
 
-  const renderSectionHeader = (title: string, description: string, enabled: boolean, setEnabled: (v: boolean) => void) => (
+  const renderSectionHeader = (
+    title: string,
+    description: string,
+    enabled: boolean,
+    toggle: () => void
+  ) => (
     <div className="flex justify-between items-start mb-4">
       <div>
         <div className="text-xl text-black mb-1">{title}</div>
-        <div className="text-sm text-gray-500">
-          {description}
-        </div>
+        <div className="text-sm text-gray-500">{description}</div>
       </div>
       <Switch
         checked={enabled}
-        onChange={setEnabled}
+        onChange={toggle}
         className={classNames(
           enabled ? 'bg-green-500' : 'bg-gray-300',
           'relative inline-flex h-6 w-11 items-center rounded-full transition-colors duration-200'
@@ -103,13 +111,13 @@ const UserSettingNotify = () => {
         {renderSectionHeader(
           'Email thông báo',
           'Thông báo và nhắc nhở quan trọng về tài khoản sẽ không thể bị tắt',
-          emailMasterEnabled,
-          setEmailMasterEnabled
+          emailSettings.masterEnabled,
+          () => setEmailSettings((prev) => ({ ...prev, masterEnabled: !prev.masterEnabled }))
         )}
         <div className="ml-5 space-y-2">
-          {renderItem('Cập nhật đơn hàng', 'Cập nhật về tình trạng vận chuyển của tất cả các đơn hàng', emailOrder, setEmailOrder, emailMasterEnabled)}
-          {renderItem('Khuyến mãi', 'Cập nhật về các ưu đãi và khuyến mãi sắp tới', emailPromo, setEmailPromo, emailMasterEnabled)}
-          {renderItem('Khảo sát', 'Đồng ý nhận khảo sát để cho chúng tôi được lắng nghe bạn', emailSurvey, setEmailSurvey, emailMasterEnabled)}
+          {renderItem('Cập nhật đơn hàng', 'Cập nhật về tình trạng vận chuyển của tất cả các đơn hàng', emailSettings.order, (v) => setEmailSettings((prev) => ({ ...prev, order: v })), emailSettings.masterEnabled)}
+          {renderItem('Khuyến mãi', 'Cập nhật về các ưu đãi và khuyến mãi sắp tới', emailSettings.promo, (v) => setEmailSettings((prev) => ({ ...prev, promo: v })), emailSettings.masterEnabled)}
+          {renderItem('Khảo sát', 'Đồng ý nhận khảo sát để cho chúng tôi được lắng nghe bạn', emailSettings.survey, (v) => setEmailSettings((prev) => ({ ...prev, survey: v })), emailSettings.masterEnabled)}
         </div>
       </div>
 
@@ -118,11 +126,11 @@ const UserSettingNotify = () => {
         {renderSectionHeader(
           'Thông báo SMS',
           'Thông báo và nhắc nhở quan trọng về tài khoản sẽ không thể bị tắt',
-          smsMasterEnabled,
-          setSmsMasterEnabled
+          smsSettings.masterEnabled,
+          () => setSmsSettings((prev) => ({ ...prev, masterEnabled: !prev.masterEnabled }))
         )}
         <div className="ml-5 space-y-2">
-          {renderItem('Khuyến mãi', 'Cập nhật về các ưu đãi và khuyến mãi sắp tới', smsPromo, setSmsPromo, smsMasterEnabled)}
+          {renderItem('Khuyến mãi', 'Cập nhật về các ưu đãi và khuyến mãi sắp tới', smsSettings.promo, (v) => setSmsSettings((prev) => ({ ...prev, promo: v })), smsSettings.masterEnabled)}
         </div>
       </div>
 
@@ -131,11 +139,11 @@ const UserSettingNotify = () => {
         {renderSectionHeader(
           'Thông báo Zalo',
           'Thông báo và nhắc nhở quan trọng về tài khoản sẽ không thể bị tắt',
-          zaloMasterEnabled,
-          setZaloMasterEnabled
+          zaloSettings.masterEnabled,
+          () => setZaloSettings((prev) => ({ ...prev, masterEnabled: !prev.masterEnabled }))
         )}
         <div className="ml-5 space-y-2">
-          {renderItem('Khuyến mãi (Shopee Việt Nam)', 'Cập nhật về các ưu đãi và khuyến mãi sắp tới', zaloPromo, setZaloPromo, zaloMasterEnabled)}
+          {renderItem('Khuyến mãi (Shopee Việt Nam)', 'Cập nhật về các ưu đãi và khuyến mãi sắp tới', zaloSettings.promo, (v) => setZaloSettings((prev) => ({ ...prev, promo: v })), zaloSettings.masterEnabled)}
         </div>
       </div>
     </div>

--- a/react-client/src/pages/User/pages/Account/SettingNotify/UserSettingNotify.tsx
+++ b/react-client/src/pages/User/pages/Account/SettingNotify/UserSettingNotify.tsx
@@ -1,7 +1,145 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
+import { Switch } from '@headlessui/react'
+
+function classNames(...classes: string[]) {
+  return classes.filter(Boolean).join(' ')
+}
 
 const UserSettingNotify = () => {
-  return <div>UserSettingNotify</div>
+  // Master toggles for sections
+  const [emailMasterEnabled, setEmailMasterEnabled] = useState(true)
+  const [smsMasterEnabled, setSmsMasterEnabled] = useState(true)
+  const [zaloMasterEnabled, setZaloMasterEnabled] = useState(true)
+
+  // Individual notification states
+  const [emailOrder, setEmailOrder] = useState(true)
+  const [emailPromo, setEmailPromo] = useState(true)
+  const [emailSurvey, setEmailSurvey] = useState(true)
+
+  const [smsNotify, setSmsNotify] = useState(true)
+  const [smsPromo, setSmsPromo] = useState(false)
+
+  const [zaloNotify, setZaloNotify] = useState(true)
+  const [zaloPromo, setZaloPromo] = useState(true)
+
+  // Update individual settings when master toggle changes
+  useEffect(() => {
+    if (!emailMasterEnabled) {
+      setEmailOrder(false)
+      setEmailPromo(false)
+      setEmailSurvey(false)
+    }
+  }, [emailMasterEnabled])
+
+  useEffect(() => {
+    if (!smsMasterEnabled) {
+      setSmsNotify(false)
+      setSmsPromo(false)
+    }
+  }, [smsMasterEnabled])
+
+  useEffect(() => {
+    if (!zaloMasterEnabled) {
+      setZaloNotify(false)
+      setZaloPromo(false)
+    }
+  }, [zaloMasterEnabled])
+
+  const renderItem = (title: string, desc: string, enabled: boolean, setEnabled: (v: boolean) => void, masterEnabled: boolean) => (
+    <div className={`flex justify-between items-start py-3 border-b border-gray-100 ${!masterEnabled ? 'opacity-50' : ''}`}>
+      <div>
+        <div className="text-black text-[16px] font-medium">{title}</div>
+        <div className="text-sm text-gray-500">{desc}</div>
+      </div>
+      <Switch
+        checked={masterEnabled && enabled}
+        onChange={setEnabled}
+        disabled={!masterEnabled}
+        className={classNames(
+          masterEnabled && enabled ? 'bg-green-500' : 'bg-gray-300',
+          'relative inline-flex h-6 w-11 items-center rounded-full transition-colors duration-200'
+        )}
+      >
+        <span
+          className={classNames(
+            masterEnabled && enabled ? 'translate-x-6' : 'translate-x-1',
+            'inline-block h-4 w-4 transform rounded-full bg-white transition-transform duration-200'
+          )}
+        />
+      </Switch>
+    </div>
+  )
+
+  const renderSectionHeader = (title: string, description: string, enabled: boolean, setEnabled: (v: boolean) => void) => (
+    <div className="flex justify-between items-start mb-4">
+      <div>
+        <div className="text-xl text-black mb-1">{title}</div>
+        <div className="text-sm text-gray-500">
+          {description}
+        </div>
+      </div>
+      <Switch
+        checked={enabled}
+        onChange={setEnabled}
+        className={classNames(
+          enabled ? 'bg-green-500' : 'bg-gray-300',
+          'relative inline-flex h-6 w-11 items-center rounded-full transition-colors duration-200'
+        )}
+      >
+        <span
+          className={classNames(
+            enabled ? 'translate-x-6' : 'translate-x-1',
+            'inline-block h-4 w-4 transform rounded-full bg-white transition-transform duration-200'
+          )}
+        />
+      </Switch>
+    </div>
+  )
+
+  return (
+    <div className="max-w-5xl mx-auto p-4 bg-white rounded-sm shadow-md min-h-[600px] flex flex-col space-y-6">
+      {/* EMAIL */}
+      <div>
+        {renderSectionHeader(
+          'Email thông báo',
+          'Thông báo và nhắc nhở quan trọng về tài khoản sẽ không thể bị tắt',
+          emailMasterEnabled,
+          setEmailMasterEnabled
+        )}
+        <div className="ml-5 space-y-2">
+          {renderItem('Cập nhật đơn hàng', 'Cập nhật về tình trạng vận chuyển của tất cả các đơn hàng', emailOrder, setEmailOrder, emailMasterEnabled)}
+          {renderItem('Khuyến mãi', 'Cập nhật về các ưu đãi và khuyến mãi sắp tới', emailPromo, setEmailPromo, emailMasterEnabled)}
+          {renderItem('Khảo sát', 'Đồng ý nhận khảo sát để cho chúng tôi được lắng nghe bạn', emailSurvey, setEmailSurvey, emailMasterEnabled)}
+        </div>
+      </div>
+
+      {/* SMS */}
+      <div>
+        {renderSectionHeader(
+          'Thông báo SMS',
+          'Thông báo và nhắc nhở quan trọng về tài khoản sẽ không thể bị tắt',
+          smsMasterEnabled,
+          setSmsMasterEnabled
+        )}
+        <div className="ml-5 space-y-2">
+          {renderItem('Khuyến mãi', 'Cập nhật về các ưu đãi và khuyến mãi sắp tới', smsPromo, setSmsPromo, smsMasterEnabled)}
+        </div>
+      </div>
+
+      {/* ZALO */}
+      <div>
+        {renderSectionHeader(
+          'Thông báo Zalo',
+          'Thông báo và nhắc nhở quan trọng về tài khoản sẽ không thể bị tắt',
+          zaloMasterEnabled,
+          setZaloMasterEnabled
+        )}
+        <div className="ml-5 space-y-2">
+          {renderItem('Khuyến mãi (Shopee Việt Nam)', 'Cập nhật về các ưu đãi và khuyến mãi sắp tới', zaloPromo, setZaloPromo, zaloMasterEnabled)}
+        </div>
+      </div>
+    </div>
+  )
 }
 
 export default UserSettingNotify


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/660c1856-c0cf-4e93-be76-0266322b3574)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an enhanced notification settings interface that allows users to effortlessly manage preferences for email, SMS, and messaging alerts using intuitive toggle switches. The updated page now automatically adjusts individual notification options when a master control is toggled off, ensuring a streamlined and responsive experience.
  - Added a new dependency for improved UI components.
  
- **Bug Fixes**
  - Improved data structure for user addresses, allowing multiple addresses to be associated with a user account.

- **Enhancements**
  - Expanded user response data to include address information and refined notification settings structure for better clarity and usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->